### PR TITLE
'run' script now sets environment variables to help find shared libraries

### DIFF
--- a/scripts/debug_linux
+++ b/scripts/debug_linux
@@ -14,6 +14,9 @@ fi
 
 # If we found the binary...
 if [ $? -eq 0 ]; then
+    # Set environment variables
+    . ./scripts/set_env_linux
+
     # Run gdb
     exec gdb ./build/bin/midistar "$@"
 fi

--- a/scripts/debug_osx
+++ b/scripts/debug_osx
@@ -15,8 +15,8 @@ fi
 
 # If we found the binary...
 if [ $? -eq 0 ]; then
-    # Dynamic library search path hack
-    export DYLD_LIBRARY_PATH="external/midifile/lib:external/rtmidi/.libs"
+    # Set environment variables
+    . ./scripts/set_env_osx
 
     # Run gdb
     exec gdb ./build/bin/midistar "$@"

--- a/scripts/run_linux
+++ b/scripts/run_linux
@@ -14,6 +14,9 @@ fi
 
 # If we found the binary...
 if [ $? -eq 0 ]; then
+    # Set environment variables
+    . ./scripts/set_env_linux
+
     # Run executable
     exec ./build/bin/midistar "$@"
 fi

--- a/scripts/run_osx
+++ b/scripts/run_osx
@@ -14,8 +14,9 @@ fi
 
 # If we found the binary...
 if [ $? -eq 0 ]; then
-    # Dynamic library search path hack
-    export DYLD_LIBRARY_PATH="external/midifile/lib:external/rtmidi/.libs"
+    # Set environment variables
+    . ./scripts/set_env_osx
+
     # Run executable
     exec ./build/bin/midistar "$@"
 fi

--- a/scripts/set_env_linux
+++ b/scripts/set_env_linux
@@ -2,3 +2,4 @@
 
 # Set LD_LIBRARY_PATH to find shared libraries
 export LD_LIBRARY_PATH="external/fluidsynth/src:external/midifile/lib:external/rtmidi/.libs:external/SFML/build/lib"
+

--- a/scripts/set_env_linux
+++ b/scripts/set_env_linux
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Set LD_LIBRARY_PATH to find shared libraries
+export LD_LIBRARY_PATH="external/fluidsynth/src:external/midifile/lib:external/rtmidi/.libs:external/SFML/build/lib"

--- a/scripts/set_env_osx
+++ b/scripts/set_env_osx
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Set DYLD_LIBRARY_PATH to find shared libraries
+export DYLD_LIBRARY_PATH="external/midifile/lib:external/rtmidi/.libs:external/SFML/build/lib"
+
+# Set DYLD_FRAMEWORK_PATH to find fluidsynth framework
+export DYLD_FRAMEWORK_PATH="external/fluidsynth/src"

--- a/scripts/set_env_osx
+++ b/scripts/set_env_osx
@@ -5,3 +5,4 @@ export DYLD_LIBRARY_PATH="external/midifile/lib:external/rtmidi/.libs:external/S
 
 # Set DYLD_FRAMEWORK_PATH to find fluidsynth framework
 export DYLD_FRAMEWORK_PATH="external/fluidsynth/src"
+


### PR DESCRIPTION
This fixes issue #8. 

On Linux, `LD_LIBRARY_PATH` is set to help find shared libraries. On OSX, `DYLD_LIBRARY_PATH` and `DYLD_FRAMEWORK_PATH` are both set to help find shared libraries.