### PR TITLE
Fixed a bug where overlapping notes were not correctly played by 'auto_play'

### DIFF
--- a/include/midistar/InstrumentCollisionHandlerComponent.h
+++ b/include/midistar/InstrumentCollisionHandlerComponent.h
@@ -47,6 +47,10 @@ class InstrumentCollisionHandlerComponent : public CollisionHandlerComponent {
  private:
     void HandleCollision(Game* g, GameObject* o, GameObject* collider);
                                                      //!< Handles a collision
+
+    GameObject* colliding_note_;  //!< Holds the note we are colliding with. We
+                     //!< need to keep track of this to play overlapping notes.
+                                                     
 };
 
 }  // End namespace midistar


### PR DESCRIPTION
* InstrumentCollisionHandlerComponent now keeps track of which GameObject it is colliding with, which allows 'auto_play' to correctly play overlapping notes.